### PR TITLE
Allow datadog tags as varargs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,28 +34,28 @@ Annotate sends an annotation.
 #### func (*Client) Decr
 
 ```go
-func (c *Client) Decr(name string) error
+func (c *Client) Decr(name string, tags ...string) error
 ```
 Decr decrements the counter for the given bucket by 1 at a rate of 1.
 
 #### func (*Client) DecrBy
 
 ```go
-func (c *Client) DecrBy(name string, value int) error
+func (c *Client) DecrBy(name string, value int, tags ...string) error
 ```
 DecrBy decrements the counter for the given bucket by N at a rate of 1.
 
 #### func (*Client) Decrement
 
 ```go
-func (c *Client) Decrement(name string, count int, rate float64) error
+func (c *Client) Decrement(name string, count int, rate float64, tags ...string) error
 ```
 Decrement decrements the counter for the given bucket.
 
 #### func (*Client) Duration
 
 ```go
-func (c *Client) Duration(name string, duration time.Duration) error
+func (c *Client) Duration(name string, duration time.Duration, tags ...string) error
 ```
 Duration records time spent for the given bucket with time.Duration.
 
@@ -71,14 +71,14 @@ Unsupported.
 #### func (*Client) Gauge
 
 ```go
-func (c *Client) Gauge(name string, value int) error
+func (c *Client) Gauge(name string, value int, tags ...string) error
 ```
 Gauge records arbitrary values for the given bucket.
 
 #### func (*Client) Histogram
 
 ```go
-func (c *Client) Histogram(name string, value int) error
+func (c *Client) Histogram(name string, value int, tags ...string) error
 ```
 Histogram is an alias of .Duration() until the statsd protocol figures its shit
 out.
@@ -86,21 +86,21 @@ out.
 #### func (*Client) Incr
 
 ```go
-func (c *Client) Incr(name string) error
+func (c *Client) Incr(name string, tags ...string) error
 ```
 Incr increments the counter for the given bucket by 1 at a rate of 1.
 
 #### func (*Client) IncrBy
 
 ```go
-func (c *Client) IncrBy(name string, n int) error
+func (c *Client) IncrBy(name string, n int, tags ...string) error
 ```
 IncrBy increments the counter for the given bucket by N at a rate of 1.
 
 #### func (*Client) Increment
 
 ```go
-func (c *Client) Increment(name string, count int, rate float64) error
+func (c *Client) Increment(name string, count int, rate float64, tags ...string) error
 ```
 Increment increments the counter for the given bucket.
 

--- a/datadog.go
+++ b/datadog.go
@@ -3,8 +3,9 @@
 package datadog
 
 import (
-	"github.com/ooyala/go-dogstatsd"
 	"time"
+
+	"github.com/ooyala/go-dogstatsd"
 )
 
 // Client.
@@ -26,48 +27,48 @@ func New(addr string) (*Client, error) {
 }
 
 // Increment increments the counter for the given bucket.
-func (c *Client) Increment(name string, count int, rate float64) error {
-	return c.DataDog.Count(name, int64(count), nil, rate)
+func (c *Client) Increment(name string, count int, rate float64, tags ...string) error {
+	return c.DataDog.Count(name, int64(count), tags, rate)
 }
 
 // Incr increments the counter for the given bucket by 1 at a rate of 1.
-func (c *Client) Incr(name string) error {
-	return c.Increment(name, 1, 1)
+func (c *Client) Incr(name string, tags ...string) error {
+	return c.Increment(name, 1, 1, tags...)
 }
 
 // IncrBy increments the counter for the given bucket by N at a rate of 1.
-func (c *Client) IncrBy(name string, n int) error {
-	return c.Increment(name, n, 1)
+func (c *Client) IncrBy(name string, n int, tags ...string) error {
+	return c.Increment(name, n, 1, tags...)
 }
 
 // Decrement decrements the counter for the given bucket.
-func (c *Client) Decrement(name string, count int, rate float64) error {
-	return c.Increment(name, -count, rate)
+func (c *Client) Decrement(name string, count int, rate float64, tags ...string) error {
+	return c.Increment(name, -count, rate, tags...)
 }
 
 // Decr decrements the counter for the given bucket by 1 at a rate of 1.
-func (c *Client) Decr(name string) error {
-	return c.Increment(name, -1, 1)
+func (c *Client) Decr(name string, tags ...string) error {
+	return c.Increment(name, -1, 1, tags...)
 }
 
 // DecrBy decrements the counter for the given bucket by N at a rate of 1.
-func (c *Client) DecrBy(name string, value int) error {
-	return c.Increment(name, -value, 1)
+func (c *Client) DecrBy(name string, value int, tags ...string) error {
+	return c.Increment(name, -value, 1, tags...)
 }
 
 // Duration records time spent for the given bucket with time.Duration.
-func (c *Client) Duration(name string, duration time.Duration) error {
-	return c.Histogram(name, millisecond(duration))
+func (c *Client) Duration(name string, duration time.Duration, tags ...string) error {
+	return c.Histogram(name, millisecond(duration), tags...)
 }
 
 // Histogram is an alias of .Duration() until the statsd protocol figures its shit out.
-func (c *Client) Histogram(name string, value int) error {
-	return c.DataDog.Histogram(name, float64(value), nil, 1)
+func (c *Client) Histogram(name string, value int, tags ...string) error {
+	return c.DataDog.Histogram(name, float64(value), tags, 1)
 }
 
 // Gauge records arbitrary values for the given bucket.
-func (c *Client) Gauge(name string, value int) error {
-	return c.DataDog.Gauge(name, float64(value), nil, 1)
+func (c *Client) Gauge(name string, value int, tags ...string) error {
+	return c.DataDog.Gauge(name, float64(value), tags, 1)
 }
 
 // Annotate sends an annotation.

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -1,7 +1,0 @@
-package datadog
-
-import (
-	"github.com/statsd/client-interface"
-)
-
-var _ statsd.Client = (*Client)(nil)


### PR DESCRIPTION
:warning: Breaks compatibility with `github.com/statsd/client-interface`

@tj 
