### PR TITLE
refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+test:
+	@go test -cover .
+
+bench:
+	@go test -bench=. -benchmem
+
+.PHONY: bench test

--- a/datadog_bench_test.go
+++ b/datadog_bench_test.go
@@ -1,0 +1,73 @@
+package datadog
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+func BenchmarkGauge(b *testing.B) {
+	c := New(ioutil.Discard)
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			c.Gauge("free.memory", 512, "program:counters")
+		}
+	})
+}
+
+func BenchmarkIncr(b *testing.B) {
+	c := New(ioutil.Discard)
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			c.Incr("counter", "program:counters")
+		}
+	})
+}
+
+func BenchmarkDecr(b *testing.B) {
+	c := New(ioutil.Discard)
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			c.Decr("counter", "program:counters")
+		}
+	})
+}
+
+func BenchmarkHistogram(b *testing.B) {
+	c := New(ioutil.Discard)
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			c.Histogram("response.size", 512, "program:server")
+		}
+	})
+}
+
+func BenchmarkDuration(b *testing.B) {
+	c := New(ioutil.Discard)
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			c.Duration("response.time", time.Second, "program:counters")
+		}
+	})
+}
+
+func BenchmarkUnique(b *testing.B) {
+	c := New(ioutil.Discard)
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			c.Unique("users", "1", "program:counters")
+		}
+	})
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -1,0 +1,162 @@
+package datadog
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bmizerany/assert"
+)
+
+func init() {
+	go func() {
+		a, err := net.ResolveUDPAddr("udp", ":5000")
+		check(err)
+
+		c, err := net.ListenUDP("udp", a)
+		check(err)
+
+		buf := make([]byte, 1024)
+
+		for {
+			_, _, err := c.ReadFromUDP(buf)
+			check(err)
+		}
+	}()
+}
+
+func TestWrites(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.Gauge("memory", 512)
+	client.Incr("count")
+	client.Decr("count")
+	client.Flush()
+
+	assert.Equal(t, "\n"+buf.String(), `
+memory:512|g
+count:1|c
+count:-1|c`)
+}
+
+func TestWritesWithTags(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.Gauge("memory", 512, "tag:a")
+	client.Incr("count", "tag:b")
+	client.Decr("count", "tag:c")
+	client.Flush()
+
+	assert.Equal(t, "\n"+buf.String(), `
+memory:512|g|#tag:a
+count:1|c|#tag:b
+count:-1|c|#tag:c`)
+}
+
+func TestWritesGlobalTags(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.SetTags("global:tag")
+	client.Gauge("memory", 512, "tag:a")
+	client.Incr("count", "tag:b")
+	client.Decr("count", "tag:c")
+	client.Flush()
+
+	assert.Equal(t, "\n"+buf.String(), `
+memory:512|g|#global:tag,tag:a
+count:1|c|#global:tag,tag:b
+count:-1|c|#global:tag,tag:c`)
+}
+
+func TestPrefix(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.SetPrefix("myprogram")
+	client.Gauge("memory", 512)
+	client.Incr("count")
+	client.Decr("count")
+	client.Flush()
+
+	assert.Equal(t, "\n"+buf.String(), `
+myprogram.memory:512|g
+myprogram.count:1|c
+myprogram.count:-1|c`)
+}
+
+func TestHistogram(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.Histogram("size", 512)
+	client.Flush()
+
+	assert.Equal(t, buf.String(), `size:512|h`)
+}
+
+func TestDuration(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.Duration("duration", time.Second)
+	client.Flush()
+
+	assert.Equal(t, buf.String(), `duration:1000|h`)
+}
+
+func TestUnique(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.Unique("users", "68b260d7c0")
+	client.Flush()
+
+	assert.Equal(t, buf.String(), `users:68b260d7c0|s`)
+}
+
+func TestRate(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.rand = func() float64 { return .4 }
+	client.SetPrefix("program")
+	client.SetTags("env:stage")
+	client.Increment("count", 1, 0.5)
+	client.Flush()
+
+	assert.Equal(t, buf.String(), `program.count:1|c|@0.5|#env:stage`)
+}
+
+func TestRateIgnored(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.rand = func() float64 { return .6 }
+	client.Increment("count", 1, 0.5)
+	client.Flush()
+
+	assert.Equal(t, buf.String(), ``)
+}
+
+func TestFlushWrite(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+	client.buf = bufio.NewWriterSize(buf, 20)
+
+	client.SetPrefix("program")
+	client.SetTags("env:foo")
+	client.Incr("counter-a")
+
+	assert.Equal(t, buf.String(), `program.counter-a:1|c|#env:foo`)
+}
+
+func TestDialClose(t *testing.T) {
+	c, err := Dial(":5000")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, c.Close(), nil)
+}


### PR DESCRIPTION
before:

```
BenchmarkGauge-8          300000          5244 ns/op         240 B/op         10 allocs/op
BenchmarkIncr-8           300000          4886 ns/op         208 B/op         10 allocs/op
BenchmarkDecr-8           300000          4957 ns/op         208 B/op         10 allocs/op
BenchmarkHistogram-8      300000          5241 ns/op         304 B/op         10 allocs/op
BenchmarkDuration-8       300000          5250 ns/op         240 B/op         10 allocs/op
```

after:

```
BenchmarkGauge-8         2000000           637 ns/op         276 B/op          3 allocs/op
BenchmarkIncr-8          2000000           620 ns/op         210 B/op          3 allocs/op
BenchmarkDecr-8          2000000           629 ns/op         208 B/op          3 allocs/op
BenchmarkHistogram-8     2000000           633 ns/op         276 B/op          3 allocs/op
BenchmarkDuration-8      2000000           641 ns/op         276 B/op          3 allocs/op
BenchmarkUnique-8        3000000           537 ns/op         216 B/op          2 allocs/op
```
