### PR TITLE
histogram using float64, time in seconds

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -114,14 +114,14 @@ func (c *Client) Gauge(name string, n int, tags ...string) error {
 
 // Histogram measures the statistical distribution of a metric `name`
 // with the given `v` value, `rate` and `tags`.
-func (c *Client) Histogram(name string, v int, tags ...string) error {
-	value := strconv.Itoa(v) + "|h"
+func (c *Client) Histogram(name string, v float64, tags ...string) error {
+	value := strconv.FormatFloat(v, 'f', -1, 64) + "|h"
 	return c.send(name, value, 1, tags)
 }
 
 // Duration uses `Histogram()` to send the given `d` duration.
 func (c *Client) Duration(name string, d time.Duration, tags ...string) error {
-	return c.Histogram(name, int(d.Seconds()*1000), tags...)
+	return c.Histogram(name, d.Seconds(), tags...)
 }
 
 // Unique records a unique occurence of events.

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -99,14 +99,24 @@ func TestHistogram(t *testing.T) {
 	assert.Equal(t, buf.String(), `size:512|h`)
 }
 
+func TestHistogramFloat(t *testing.T) {
+	buf := new(bytes.Buffer)
+	client := New(buf)
+
+	client.Histogram("size", 0.5)
+	client.Flush()
+
+	assert.Equal(t, buf.String(), `size:0.5|h`)
+}
+
 func TestDuration(t *testing.T) {
 	buf := new(bytes.Buffer)
 	client := New(buf)
 
-	client.Duration("duration", time.Second)
+	client.Duration("duration", time.Millisecond*500)
 	client.Flush()
 
-	assert.Equal(t, buf.String(), `duration:1000|h`)
+	assert.Equal(t, buf.String(), `duration:0.5|h`)
 }
 
 func TestUnique(t *testing.T) {


### PR DESCRIPTION
This commit updates the histogram command to use float64 values so
we can pass factional values, as well as update the time duration
to be in seconds rather than milliseconds. It unifies the behavior
with segmentio/stats.